### PR TITLE
Update len.md

### DIFF
--- a/advanced/calculated-attributes/operators/len.md
+++ b/advanced/calculated-attributes/operators/len.md
@@ -7,14 +7,14 @@ items: Operators
 
 | Specification         | Value                                                        |
 | --------------------- | ------------------------------------------------------------ |
-| Description           | Returns the length of a string.           |
-| Parameter 1 Name      | String                                                         |
-| Parameter 1 Type      | string                                    |
+| Description           | Returns the length of a string.                              |
+| Parameter 1 Name      | String                                                       |
+| Parameter 1 Type      | string                                                       |
 | Parameter 2 Name      | -                                                            |
 | Parameter 2 Type      | -                                                            |
 | Parameter 3 Name      | -                                                            |
 | Parameter 3 Type      | -                                                            |
-| Return value          | The string's length.                                                  |
+| Return value          | The string's length.                                         |
 
 > [!NOTE] 
 > 
@@ -36,7 +36,9 @@ OUTPUT:
 > The repository of the attribute is *Crm.Sales.SalesOrders*.
 
 [!NOTE]
-> It is important to note that if the string being passed to the LEN function is empty or null, it will return an error. Therefore, it is recommended to add an IF > > > operator to check whether the string is empty/null before passing it to the LEN function. This will prevent any errors from occurring and ensure that the function > > works as intended.
+> It is important to note that if the string being passed to the LEN function is null, it will return an error. Therefore, it is recommended to add an IF > > > operator to check whether the string is null before passing it to the LEN function. This will prevent any errors from occurring and ensure that the function > > 
+works as intended.
+
 **Example:**
 5	IIF	EXP	7	CONST	0	EXP	10
 7	EQUAL	ATTRIB	DocumentNotes	CONST	Null

--- a/advanced/calculated-attributes/operators/len.md
+++ b/advanced/calculated-attributes/operators/len.md
@@ -40,6 +40,6 @@ OUTPUT:
 works as intended.
 
 **Example:**
-5	IIF	EXP	7	CONST	0	EXP	10
-7	EQUAL	ATTRIB	DocumentNotes	CONST	Null
-10	LEN	ATTRIB	DocumentNotes
+10	IIF	EXP	7	CONST	0	EXP	10
+20	EQUAL	ATTRIB	DocumentNotes	CONST	Null
+30	LEN	ATTRIB	DocumentNotes

--- a/advanced/calculated-attributes/operators/len.md
+++ b/advanced/calculated-attributes/operators/len.md
@@ -34,3 +34,10 @@ OUTPUT:
 > [!NOTE] 
 > 
 > The repository of the attribute is *Crm.Sales.SalesOrders*.
+
+[!NOTE]
+> It is important to note that if the string being passed to the LEN function is empty or null, it will return an error. Therefore, it is recommended to add an IF > > > operator to check whether the string is empty/null before passing it to the LEN function. This will prevent any errors from occurring and ensure that the function > > works as intended.
+**Example:**
+5	IIF	EXP	7	CONST	0	EXP	10
+7	EQUAL	ATTRIB	DocumentNotes	CONST	Null
+10	LEN	ATTRIB	DocumentNotes


### PR DESCRIPTION
The change explains the importance of checking for empty/null strings before using the LEN operator to avoid errors.